### PR TITLE
Updated meck tag in tests rebar.config to 0.8.2, now works with r17

### DIFF
--- a/tests/rebar.config
+++ b/tests/rebar.config
@@ -12,7 +12,7 @@
 {profiles, [
     {test, [
         {deps, [
-          {meck, {git, "https://github.com/eproxus/meck.git", {tag, "0.8.1"}}}
+          {meck, {git, "https://github.com/eproxus/meck.git", {tag, "0.8.2"}}}
         ]}
     ]},
     %% called as `rebar3 as prod <command>`


### PR DESCRIPTION
When trying to run ```./rebar3 ct``` for the tests, I received this error:

```
22:07:26 [paul@dev-desktop tests]$ ./rebar3 ct
===> Verifying dependencies...
===> Compiling meck
===> Compiling /home/paul/Projects/scratch/howistart/howistart-erlang1-code/tests/_build/test/lib/meck/src/meck_proc.erl failed
/home/paul/Projects/scratch/howistart/howistart-erlang1-code/tests/_build/test/lib/meck/src/meck_proc.erl:51: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
/home/paul/Projects/scratch/howistart/howistart-erlang1-code/tests/_build/test/lib/meck/src/meck_proc.erl:408: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
/home/paul/Projects/scratch/howistart/howistart-erlang1-code/tests/_build/test/lib/meck/src/meck_proc.erl:445: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
/home/paul/Projects/scratch/howistart/howistart-erlang1-code/tests/_build/test/lib/meck/src/meck_proc.erl:446: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
/home/paul/Projects/scratch/howistart/howistart-erlang1-code/tests/_build/test/lib/meck/src/meck_proc.erl:476: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
/home/paul/Projects/scratch/howistart/howistart-erlang1-code/tests/_build/test/lib/meck/src/meck_proc.erl:477: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
/home/paul/Projects/scratch/howistart/howistart-erlang1-code/tests/_build/test/lib/meck/src/meck_proc.erl:482: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
/home/paul/Projects/scratch/howistart/howistart-erlang1-code/tests/_build/test/lib/meck/src/meck_proc.erl:483: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
/home/paul/Projects/scratch/howistart/howistart-erlang1-code/tests/_build/test/lib/meck/src/meck_proc.erl:488: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
/home/paul/Projects/scratch/howistart/howistart-erlang1-code/tests/_build/test/lib/meck/src/meck_proc.erl:489: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
```

Upgrading meck to 0.8.2 in the test rebar.config seems to have fixed the issue.
